### PR TITLE
new sql.init [N.A.]

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -41,8 +41,7 @@ CREATE TABLE loggaroo.log_entry
     user_id         VARCHAR,
     user_session_id VARCHAR,
     java_class      VARCHAR        NOT NULL,
-    content         VARCHAR,
-    sql_combined    VARCHAR,
+    content         VARCHAR        NOT NULL,
     sql_raw         VARCHAR,
     sql_data        VARCHAR,
 


### PR DESCRIPTION
changed the internal structure for sql statements to use the content field

- Userstory [N.A.]

- [Issue #122](https://tree.taiga.io/project/jonaspfeifer05-loggeroo/issue/122)